### PR TITLE
feat(qq): 支持 QQ GroupMessageCreateEvent 全量群消息事件

### DIFF
--- a/nonebot_plugin_session/adapters/qq.py
+++ b/nonebot_plugin_session/adapters/qq.py
@@ -14,7 +14,6 @@ try:
         EventType,
         ForumEvent,
         GroupAtMessageCreateEvent,
-        GroupMessageCreateEvent,
         GroupRobotEvent,
         GuildEvent,
         GuildMemberEvent,
@@ -25,6 +24,15 @@ try:
         PublicMessageDeleteEvent,
     )
 
+    # GroupMessageCreateEvent 是 adapter-qq >= 1.7.0 新增的，
+    # 低版本适配器不会注册该事件的提取器
+    try:
+        from nonebot.adapters.qq import GroupMessageCreateEvent
+    except ImportError:
+        GroupMessageCreateEvent = None
+
+    _HAS_GROUP_MESSAGE = hasattr(EventType, "GROUP_MESSAGE_CREATE")
+
     @register_session_extractor(Bot, Event)
     class EventExtractor(SessionExtractor[Bot, Event]):
         def extract_platform(self) -> str:
@@ -32,7 +40,6 @@ try:
                 # C2C_GROUP_AT_MESSAGES
                 EventType.C2C_MESSAGE_CREATE,
                 EventType.GROUP_AT_MESSAGE_CREATE,
-                EventType.GROUP_MESSAGE_CREATE,
                 # FRIEND_ROBOT_EVENT
                 EventType.FRIEND_ADD,
                 EventType.FRIEND_DEL,
@@ -43,7 +50,8 @@ try:
                 EventType.GROUP_DEL_ROBOT,
                 EventType.GROUP_MSG_REJECT,
                 EventType.GROUP_MSG_RECEIVE,
-            ]:
+            ] or (_HAS_GROUP_MESSAGE
+                  and self.event.__type__ == EventType.GROUP_MESSAGE_CREATE):
                 return SupportedPlatform.qq
 
             elif self.event.__type__ in [
@@ -125,7 +133,11 @@ try:
 
             elif self.event.__type__ in [
                 EventType.GROUP_AT_MESSAGE_CREATE,
-                EventType.GROUP_MESSAGE_CREATE,
+            ] or (_HAS_GROUP_MESSAGE
+                  and self.event.__type__ == EventType.GROUP_MESSAGE_CREATE):
+                return SessionLevel.LEVEL2
+
+            elif self.event.__type__ in [
                 # GROUP_ROBOT_EVENT
                 EventType.GROUP_ADD_ROBOT,
                 EventType.GROUP_DEL_ROBOT,
@@ -152,6 +164,9 @@ try:
                 # GUILD_MESSAGE_REACTIONS
                 EventType.MESSAGE_REACTION_ADD,
                 EventType.MESSAGE_REACTION_REMOVE,
+                # DIRECT_MESSAGE
+                EventType.DIRECT_MESSAGE_CREATE,
+                EventType.DIRECT_MESSAGE_DELETE,
                 # OPEN_FORUMS_EVENT
                 EventType.OPEN_FORUM_THREAD_CREATE,
                 EventType.OPEN_FORUM_THREAD_UPDATE,
@@ -193,11 +208,13 @@ try:
         def extract_id2(self) -> Optional[str]:
             if isinstance(
                 self.event,
-                (
-                    GroupAtMessageCreateEvent,
-                    GroupMessageCreateEvent,
-                    GroupRobotEvent,
-                ),
+                (GroupAtMessageCreateEvent, GroupRobotEvent),
+            ):
+                return self.event.group_openid
+
+            if (
+                GroupMessageCreateEvent is not None
+                and isinstance(self.event, GroupMessageCreateEvent)
             ):
                 return self.event.group_openid
 

--- a/nonebot_plugin_session/adapters/qq.py
+++ b/nonebot_plugin_session/adapters/qq.py
@@ -14,6 +14,7 @@ try:
         EventType,
         ForumEvent,
         GroupAtMessageCreateEvent,
+        GroupMessageCreateEvent,
         GroupRobotEvent,
         GuildEvent,
         GuildMemberEvent,
@@ -31,6 +32,7 @@ try:
                 # C2C_GROUP_AT_MESSAGES
                 EventType.C2C_MESSAGE_CREATE,
                 EventType.GROUP_AT_MESSAGE_CREATE,
+                EventType.GROUP_MESSAGE_CREATE,
                 # FRIEND_ROBOT_EVENT
                 EventType.FRIEND_ADD,
                 EventType.FRIEND_DEL,
@@ -123,6 +125,7 @@ try:
 
             elif self.event.__type__ in [
                 EventType.GROUP_AT_MESSAGE_CREATE,
+                EventType.GROUP_MESSAGE_CREATE,
                 # GROUP_ROBOT_EVENT
                 EventType.GROUP_ADD_ROBOT,
                 EventType.GROUP_DEL_ROBOT,
@@ -192,6 +195,7 @@ try:
                 self.event,
                 (
                     GroupAtMessageCreateEvent,
+                    GroupMessageCreateEvent,
                     GroupRobotEvent,
                 ),
             ):

--- a/tests/test_qq.py
+++ b/tests/test_qq.py
@@ -9,6 +9,7 @@ from nonebot.adapters.qq.event import (
     DirectMessageCreateEvent,
     EventType,
     GroupAtMessageCreateEvent,
+    GroupMessageCreateEvent,
     GuildDeleteEvent,
     MessageCreateEvent,
     MessageDeleteEvent,
@@ -113,11 +114,38 @@ def test_group_at_message_create_event(app: App):
     bot = new_bot(self_id="2233")
     event = GroupAtMessageCreateEvent(
         id="id",
-        __type__=EventType.C2C_MESSAGE_CREATE,
+        __type__=EventType.GROUP_AT_MESSAGE_CREATE,
         content="test",
         timestamp="2023-01-01T00:00:00",
-        author=GroupMemberAuthor(id="1111", member_openid="3344"),
+        author=GroupMemberAuthor(id="1111", bot=False, member_openid="3344"),
         group_openid="6677",
+        group_id="group_id",
+    )
+    session = extract_session(bot, event)
+    assert_session(
+        session,
+        bot_id="2233",
+        bot_type="QQ",
+        platform="qq",
+        level=SessionLevel.LEVEL2,
+        id1="3344",
+        id2="6677",
+        id3=None,
+    )
+
+
+def test_group_message_create_event(app: App):
+    from nonebot_plugin_session import SessionLevel, extract_session
+
+    bot = new_bot(self_id="2233")
+    event = GroupMessageCreateEvent(
+        id="id",
+        __type__=EventType.GROUP_MESSAGE_CREATE,
+        content="test",
+        timestamp="2023-01-01T00:00:00",
+        author=GroupMemberAuthor(id="1111", bot=False, member_openid="3344"),
+        group_openid="6677",
+        group_id="group_id",
     )
     session = extract_session(bot, event)
     assert_session(


### PR DESCRIPTION
## 背景

QQ adapter (adapter-qq) v1.7.0+ 新增了 `GroupMessageCreateEvent`（`EventType.GROUP_MESSAGE_CREATE`），用于接收**不需要 @ 机器人**的全量群消息。`GroupAtMessageCreateEvent` 现已继承自此类。

## 改动

| 文件 | 改动 |
|---|---|
| `nonebot_plugin_session/adapters/qq.py` | 添加 `GroupMessageCreateEvent` 导入（独立 try/except 兼容低版本） |
| 同上 - `extract_platform()` | 通过 `_HAS_GROUP_MESSAGE` 标志守卫，高版本 ⮕ `qq` |
| 同上 - `extract_level()` | 同上 ⮕ `LEVEL2` |
| 同上 - `extract_id2()` | 同上 ⮕ `self.event.group_openid` |
| `tests/test_qq.py` | 新增 `test_group_message_create_event`；修复 `test_group_at_message_create_event` 的 `__type__` 误写为 `C2C_MESSAGE_CREATE` 的问题；适配 adapter-qq v1.7.1 模型变化 |

## 兼容性

- **adapter-qq < 1.7.0**：`GroupMessageCreateEvent` 导入失败时设为 `None`，`isinstance` 检查搭配 `is not None` 守卫，不会报错
- **adapter-qq >= 1.7.0**：自动启用新事件支持
- `EventType.GROUP_MESSAGE_CREATE` 的访问用 `hasattr(EventType, ...)` 守卫，低版本不会触发 `AttributeError`